### PR TITLE
Add Windows non-Docker quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ from a single workstation to global media operations.
 
 ## Quick start
 
+### Windows 11 (no Docker, simplest)
+
+1. Install Python 3.10+ from https://www.python.org/downloads/windows/ (check “Add python.exe to PATH”).
+2. Double-click `start.bat` in this repo.
+
+The script creates a virtual environment, installs dependencies, generates a secret key if needed, and starts the app at
+`http://127.0.0.1:5000`.
+
 ### Docker (dev)
 
 ```bash
@@ -43,6 +51,15 @@ git clone https://github.com/GlowhavenIndustries/Glowhaven-Media-Orchestrator.gi
 ```bash
 python3 -m venv venv
 source venv/bin/activate
+pip install -r requirements.txt
+python app.py
+```
+
+### Windows (manual)
+
+```bat
+python -m venv venv
+venv\Scripts\activate
 pip install -r requirements.txt
 python app.py
 ```


### PR DESCRIPTION
### Motivation

- Provide an easy, no-Docker quick start for Windows 11 users who cannot or do not want to run Docker. 
- Surface the existing `start.bat` workflow and a simple manual Windows setup so Windows users can run the app with minimal steps.

### Description

- Updated `README.md` to add a `Windows 11 (no Docker, simplest)` section that directs users to install Python and double-click `start.bat` to boot the app. 
- Added a `Windows (manual)` snippet with the equivalent manual commands using `python -m venv venv`, `venv\Scripts\activate`, `pip install -r requirements.txt`, and `python app.py`. 
- Left existing Docker and Python developer instructions intact.

### Testing

- This is a documentation-only change, so no automated tests were run. 
- No test failures were introduced because no code was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982a42965a08320a00f0fb9815d6aaf)