### PR TITLE
Set explicit Flask instance path for script runs

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from flask import Flask, flash, redirect, render_template, request, send_file, url_for
 from spotipy.exceptions import SpotifyException
@@ -19,7 +20,7 @@ def build_plugin_registry(config: OrchestratorConfig) -> PluginRegistry:
 
 def create_app():
     """Create and configure the Flask application."""
-    app = Flask(__name__)
+    app = Flask(__name__, instance_path=os.path.abspath(os.path.dirname(__file__)))
 
     try:
         from dotenv import load_dotenv


### PR DESCRIPTION
### Motivation
- Ensure the Flask `instance_path` resolves correctly when running the application file directly to avoid instance-directory resolution errors.

### Description
- Import `os` and initialize the app with an explicit instance path using `Flask(__name__, instance_path=os.path.abspath(os.path.dirname(__file__)))`.

### Testing
- No automated test suite was run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982a7d118b08320b1631a4f3c6620d4)