### PR TITLE
Bump Flask and Werkzeug for Python 3.12 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.2.5
-Werkzeug==2.2.2
+Flask==2.3.3
+Werkzeug==2.3.8
 spotipy==2.22.1
 gunicorn==20.1.0
 waitress==2.1.2


### PR DESCRIPTION
### Motivation
- Fix runtime failures when running under Python 3.12 (e.g. `AttributeError: module 'ast' has no attribute 'Str'` from older Werkzeug/Flask versions) by upgrading the frameworks to releases compatible with the newer Python AST changes.

### Description
- Update `requirements.txt` to replace `Flask==2.2.5` with `Flask==2.3.3` and `Werkzeug==2.2.2` with `Werkzeug==2.3.8` as a dependency-only change.

### Testing
- No automated tests were run locally for this dependency-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69830c0678488320aceab5c795350428)